### PR TITLE
Bring back support for external matchmaking

### DIFF
--- a/js/connect4.js
+++ b/js/connect4.js
@@ -141,15 +141,15 @@ function initialize() {
   var joinID = urlParams.get("joinid");
   var createID = urlParams.get("createid");
 
-  console.log(joinID);
-  console.log(createID);
-
   if (joinID) {
     // remove the params from the url in the browser bar
-    window.history.replaceState({}, document.title, "/");
+    window.history.replaceState(null, null, window.location.pathname);
 
     startJoin(joinID);
   } else if (createID) {
+    // remove the params from the url in the browser bar
+    window.history.replaceState(null, null, window.location.pathname);
+
     start(
       new RemotePlayer(helperMethods, {
         isHost: true,

--- a/js/connect4.js
+++ b/js/connect4.js
@@ -138,13 +138,25 @@ function initialize() {
   $("#copyBox").hide();
 
   var urlParams = new URLSearchParams(window.location.search);
-  var joinID = urlParams.get("id");
+  var joinID = urlParams.get("joinid");
+  var createID = urlParams.get("createid");
+
+  console.log(joinID);
+  console.log(createID);
 
   if (joinID) {
     // remove the params from the url in the browser bar
     window.history.replaceState({}, document.title, "/");
 
     startJoin(joinID);
+  } else if (createID) {
+    start(
+      new RemotePlayer(helperMethods, {
+        isHost: true,
+        createID
+      }),
+      new LocalPlayer(helperMethods)
+    );
   } else {
     //popup the gamemode selector
     gamemodeSelector();

--- a/js/players/remotePlayer.js
+++ b/js/players/remotePlayer.js
@@ -1,5 +1,7 @@
 var RemotePlayer = function(helperMethods, data) {
-  var peer = new Peer();
+  // if data.createID doesn't exist, peerjs will generate its own
+  var peer = new Peer(data.createID);
+
   var connection;
   var hasBeenReset = false;
 
@@ -11,14 +13,28 @@ var RemotePlayer = function(helperMethods, data) {
     console.log("Connected to Peer.js server!");
   });
 
-  function initHost(onReady) {
+  function internalHost() {
     var url = window.location.href.split("?")[0];
     var gameStatus = "Send this link to the other player: ";
-    var link = url + "?id=" + peer.id;
+    var link = url + "?joinid=" + peer.id;
     $("#hostLink").attr("value", link);
 
     console.log("Game number: " + peer.id);
     helperMethods.setGameStatus(gameStatus);
+  }
+
+  function externalHost() {
+    helperMethods.setGameStatus("Waiting for another player to join...");
+  }
+
+  function initHost(onReady) {
+    if (data.createID) {
+      // if this game was created via url
+      externalHost();
+    } else {
+      // if this game was created with the "online multiplayer" button
+      internalHost();
+    }
 
     console.log("Waiting for a player to join...");
     peer.once("connection", function(conn) {


### PR DESCRIPTION
We had this feature before the bootstrap redesign for use in Lansite matchmaking, but it was removed in favor of game codes. Since then, we got rid of game codes in favor of url copying. I had tannerkrewson/connect4lansite set up with an old version of connect4 just for lansite, but it doesn't work anymore, as per https://github.com/tannerkrewson/lansite/issues/1

This pr adds a way of "hosting" an online game without clicking the button in the menu. It adds url `kevinshannon.dev/connect4?createid=RANDOMIDHERE` which can be joined with `kevinshannon.dev/connect4?joinid=RANDOMIDHERE`. The url copying box is hidden in this mode.

Hosting and joining via the main menu is unaffected.